### PR TITLE
Add more Cargo.toml metadata fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,14 @@ name = "stytch"
 version = "1.0.0"
 edition = "2021"
 license = "MIT"
+description = "Stytch Rust client"
+documentation = "https://stytch.com/docs"
+homepage = "https://github.com/stytchauth/stytch-rust"
+categories = [
+    "api-bindings",
+    "authentication",
+    "web-programming",
+]
 
 [dependencies]
 base64 = "0.13.0"


### PR DESCRIPTION
The lack of `description` is preventing the crate from being published, and the rest are nice to have.
