### PR TITLE
Update docs and support set_email_verified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/src/b2b/discovery_organizations.rs
+++ b/src/b2b/discovery_organizations.rs
@@ -139,16 +139,16 @@ pub struct CreateRequest {
     ///   for more information about role assignment.
     pub rbac_email_implicit_role_assignments:
         std::option::Option<std::vec::Vec<EmailImplicitRoleAssignment>>,
-    /// mfa_methods: The setting that controls which mfa methods can be used by Members of an Organization. The
+    /// mfa_methods: The setting that controls which MFA methods can be used by Members of an Organization. The
     /// accepted values are:
     ///
     ///   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
     ///
-    ///   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+    ///   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
     /// This setting does not apply to Members with `is_breakglass` set to `true`.
     ///
     pub mfa_methods: std::option::Option<String>,
-    /// allowed_mfa_methods: An array of allowed mfa authentication methods. This list is enforced when
+    /// allowed_mfa_methods: An array of allowed MFA authentication methods. This list is enforced when
     /// `mfa_methods` is set to `RESTRICTED`.
     ///   The list's accepted values are: `sms_otp` and `totp`.
     ///

--- a/src/b2b/organizations.rs
+++ b/src/b2b/organizations.rs
@@ -290,16 +290,16 @@ pub struct Organization {
     /// [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/role-assignment)
     ///   for more information about role assignment.
     pub rbac_email_implicit_role_assignments: std::vec::Vec<EmailImplicitRoleAssignment>,
-    /// mfa_methods: The setting that controls which mfa methods can be used by Members of an Organization. The
+    /// mfa_methods: The setting that controls which MFA methods can be used by Members of an Organization. The
     /// accepted values are:
     ///
     ///   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
     ///
-    ///   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+    ///   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
     /// This setting does not apply to Members with `is_breakglass` set to `true`.
     ///
     pub mfa_methods: String,
-    /// allowed_mfa_methods: An array of allowed mfa authentication methods. This list is enforced when
+    /// allowed_mfa_methods: An array of allowed MFA authentication methods. This list is enforced when
     /// `mfa_methods` is set to `RESTRICTED`.
     ///   The list's accepted values are: `sms_otp` and `totp`.
     ///
@@ -435,16 +435,16 @@ pub struct CreateRequest {
     ///   for more information about role assignment.
     pub rbac_email_implicit_role_assignments:
         std::option::Option<std::vec::Vec<EmailImplicitRoleAssignment>>,
-    /// mfa_methods: The setting that controls which mfa methods can be used by Members of an Organization. The
+    /// mfa_methods: The setting that controls which MFA methods can be used by Members of an Organization. The
     /// accepted values are:
     ///
     ///   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
     ///
-    ///   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+    ///   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
     /// This setting does not apply to Members with `is_breakglass` set to `true`.
     ///
     pub mfa_methods: std::option::Option<String>,
-    /// allowed_mfa_methods: An array of allowed mfa authentication methods. This list is enforced when
+    /// allowed_mfa_methods: An array of allowed MFA authentication methods. This list is enforced when
     /// `mfa_methods` is set to `RESTRICTED`.
     ///   The list's accepted values are: `sms_otp` and `totp`.
     ///
@@ -699,20 +699,20 @@ pub struct UpdateRequest {
     /// If this field is provided and a session header is passed into the request, the Member Session must have
     /// permission to perform the `update.settings.implicit-roles` action on the `stytch.organization` Resource.
     pub rbac_email_implicit_role_assignments: std::option::Option<std::vec::Vec<String>>,
-    /// mfa_methods: The setting that controls which mfa methods can be used by Members of an Organization. The
+    /// mfa_methods: The setting that controls which MFA methods can be used by Members of an Organization. The
     /// accepted values are:
     ///
     ///   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
     ///
-    ///   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+    ///   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
     /// This setting does not apply to Members with `is_breakglass` set to `true`.
     ///
     ///
     /// If this field is provided and a session header is passed into the request, the Member Session must have
-    /// permission to perform the `update.settings.allowed-auth-methods` action on the `stytch.organization`
+    /// permission to perform the `update.settings.allowed-mfa-methods` action on the `stytch.organization`
     /// Resource.
     pub mfa_methods: std::option::Option<String>,
-    /// allowed_mfa_methods: An array of allowed mfa authentication methods. This list is enforced when
+    /// allowed_mfa_methods: An array of allowed MFA authentication methods. This list is enforced when
     /// `mfa_methods` is set to `RESTRICTED`.
     ///   The list's accepted values are: `sms_otp` and `totp`.
     ///

--- a/src/b2b/organizations_members.rs
+++ b/src/b2b/organizations_members.rs
@@ -336,7 +336,7 @@ pub struct UpdateRequest {
     /// more details.
     ///
     /// If this field is provided and a session header is passed into the request, the Member Session must have
-    /// permission to perform the `update.info.is-breakglass` action on the `stytch.member` Resource.
+    /// permission to perform the `update.settings.is-breakglass` action on the `stytch.member` Resource.
     pub is_breakglass: std::option::Option<bool>,
     /// mfa_phone_number: Sets the Member's phone number. Throws an error if the Member already has a phone
     /// number. To change the Member's phone number, use the

--- a/src/b2b/rbac.rs
+++ b/src/b2b/rbac.rs
@@ -15,23 +15,118 @@ pub struct Policy {
     pub resources: std::vec::Vec<PolicyResource>,
 }
 
+/// PolicyResource:
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PolicyResource {
+    /// resource_id: A unique identifier of the RBAC Resource, provided by the developer and intended to be
+    /// human-readable.
+    ///
+    ///   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+    /// default Resources with reserved  `resource_id`s. These include:
+    ///
+    ///   * `stytch.organization`
+    ///   * `stytch.member`
+    ///   * `stytch.sso`
+    ///   * `stytch.self`
+    ///
+    ///   Check out the
+    /// [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+    /// detailed explanation.
+    ///
+    ///
     pub resource_id: String,
+    /// description: The description of the RBAC Resource.
     pub description: String,
+    /// actions: A list of all possible actions for a provided Resource.
+    ///
+    ///   Reserved `actions` that are predefined by Stytch include:
+    ///
+    ///   * `*`
+    ///   * For the `stytch.organization` Resource:
+    /// * `update.info.name`
+    /// * `update.info.slug`
+    /// * `update.info.untrusted_metadata`
+    /// * `update.info.email_jit_provisioning`
+    /// * `update.info.logo_url`
+    /// * `update.info.email_invites`
+    /// * `update.info.allowed_domains`
+    /// * `update.info.default_sso_connection`
+    /// * `update.info.sso_jit_provisioning`
+    /// * `update.info.mfa_policy`
+    /// * `update.info.implicit_roles`
+    /// * `delete`
+    ///   * For the `stytch.member` Resource:
+    /// * `create`
+    /// * `update.info.name`
+    /// * `update.info.untrusted_metadata`
+    /// * `update.info.mfa-phone`
+    /// * `update.info.delete.mfa-phone`
+    /// * `update.settings.is-breakglass`
+    /// * `update.settings.mfa_enrolled`
+    /// * `update.settings.roles`
+    /// * `search`
+    /// * `delete`
+    ///   * For the `stytch.sso` Resource:
+    /// * `create`
+    /// * `update`
+    /// * `delete`
+    ///   * For the `stytch.self` Resource:
+    /// * `update.info.name`
+    /// * `update.info.untrusted_metadata`
+    /// * `update.info.mfa-phone`
+    /// * `update.info.delete.mfa-phone`
+    /// * `update.info.delete.password`
+    /// * `update.settings.mfa_enrolled`
+    /// * `delete`
+    ///
     pub actions: std::vec::Vec<String>,
 }
 
+/// PolicyRole:
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PolicyRole {
+    /// role_id: The unique identifier of the RBAC Role, provided by the developer and intended to be
+    /// human-readable.  
+    ///
+    ///   Reserved `role_id`s that are predefined by Stytch include:
+    ///
+    ///   * `stytch_member`
+    ///   * `stytch_admin`
+    ///
+    ///   Check out the [guide on Stytch default Roles](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults)
+    /// for a more detailed explanation.
+    ///
+    ///
     pub role_id: String,
+    /// description: The description of the RBAC Role.
     pub description: String,
+    /// permissions: A list of permissions that link a
+    /// [Resource](https://stytch.com/docs/b2b/api/rbac-resource-object) to a list of actions.
     pub permissions: std::vec::Vec<PolicyRolePermission>,
 }
 
+/// PolicyRolePermission:
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PolicyRolePermission {
+    /// resource_id: A unique identifier of the RBAC Resource, provided by the developer and intended to be
+    /// human-readable.
+    ///
+    ///   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+    /// default Resources with reserved  `resource_id`s. These include:
+    ///
+    ///   * `stytch.organization`
+    ///   * `stytch.member`
+    ///   * `stytch.sso`
+    ///   * `stytch.self`
+    ///
+    ///   Check out the
+    /// [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+    /// detailed explanation.
+    ///
+    ///
     pub resource_id: String,
+    /// actions: A list of permitted actions the Role is authorized to take with the provided Resource. You can
+    /// use `*` as a wildcard to grant a Role permission to use all possible actions related to the Resource.
     pub actions: std::vec::Vec<String>,
 }
 
@@ -52,7 +147,7 @@ pub struct PolicyResponse {
     #[serde(with = "http_serde::status_code")]
     pub status_code: http::StatusCode,
     /// policy: The RBAC Policy document that contains all defined Roles and Resources – which are managed in
-    /// the [Dashboard](/dashboard). Read more about these entities and how they work in our
+    /// the [Dashboard](/dashboard/rbac). Read more about these entities and how they work in our
     /// [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
     pub policy: std::option::Option<Policy>,
 }

--- a/src/consumer/passwords.rs
+++ b/src/consumer/passwords.rs
@@ -275,6 +275,12 @@ pub struct MigrateRequest {
     /// **cannot be used to store critical information.** See the
     /// [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior details.
     pub untrusted_metadata: std::option::Option<serde_json::Value>,
+    /// set_email_verified: Whether to set the user's email as verified. This is a dangerous field. Incorrect
+    /// use may lead to users getting erroneously
+    /// deduplicated into one user object. This flag should only be set if you can attest that the user owns the
+    /// email address in question.
+    /// Access to this field is restricted. To enable it, please send us a note at support@stytch.com.
+    pub set_email_verified: std::option::Option<bool>,
     /// name: The name of the user. Each field in the name object is optional.
     pub name: std::option::Option<Name>,
 }


### PR DESCRIPTION
1. Docs updates
2. Adds support for `set_email_verified` in passwords/migrate