### PR TITLE
Don't force native-tls on everyone using this library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,12 @@ base64 = "0.13.0"
 chrono = { version = "0.4.22", default_features = false, features = ["serde", "std"] }
 http = "0.2.8"
 http-serde = "1.1.0"
-reqwest = { version = "0.11.12", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.11.12", default-features = false, features = ["json"] }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = "1.0.82"
 thiserror = "1.0.31"
 tracing = "0.1.35"
 url = "2.2.2"
+
+[features]
+default = ["reqwest/native-tls"]


### PR DESCRIPTION
While it makes sense to include a lightweight TLS backend by default, a hard dependency on reqwest/native-tls leaves downstream crates with no way to disable the feature.