### PR TITLE
Re-export reqwest TLS features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,6 @@ tracing = "0.1.35"
 url = "2.2.2"
 
 [features]
-default = ["reqwest/native-tls"]
+default = ["reqwest-native-tls"]
+reqwest-native-tls = ["reqwest/native-tls"]
+reqwest-rustls-tls = ["reqwest/rustls-tls"]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ match resp {
 
 Learn more about errors in the [docs](https://stytch.com/docs/api/errors).
 
+## Cargo Features
+
+- `reqwest-rustls-tls`: Enable reqwest's `rustls-tls` feature for the rustls implementation.
+- `reqwest-native-tls`: Enable reqwest's `native-tls` feature for the native TLS implementation.
+  (This is enabled by default.)
+
 ## Documentation
 
 See example requests and responses for all the endpoints in the [Stytch API Reference](https://stytch.com/docs/api).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The minimum supported Rust version (MSRV) of this library is Rust 1.70.
 Use `cargo add stytch` to add this to your `Cargo.toml`:
 
 ```toml
-stytch = "1.0.0"
+stytch = "1.2.1"
 ```
 
 ## Usage


### PR DESCRIPTION
This builds on #12, which moved reqwest's native-tls feature to the `stytch` crate's default features instead of being a hard-required feature.

For libraries that don't already depend on `reqwest` directly, they'd have to add something like this to their `Cargo.toml` to be able to switch to rustls:

```diff
[dependencies]
-stytch = "1.2.0"
+stytch = { version = "1.2.0", default_features = false }
+reqwest = { version = "0.11.12", default_features = false, features = ["native-tls"] }
```

"Forwarding" the features like this is something I've seen in other libraries that depend on `reqwest`, and it saves the extra import.

I tested by checking a local test project against this crate with these three import lines for `stytch`:

```toml
stytch = { path = "../stytch-rust" } # default is native-tls
stytch = { path = "../stytch-rust", default_features = false, features = ["reqwest-native-tls"] }
stytch = { path = "../stytch-rust", default_features = false, features = ["reqwest-rustls-tls"] }
```

(These will work the same way when `path = ".."` becomes `version = "1.2.1"`.)
