### PR TITLE
chore(cargo): update `homepage` to `repository`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"
 documentation = "https://stytch.com/docs"
-homepage = "https://github.com/stytchauth/stytch-rust"
+repository = "https://github.com/stytchauth/stytch-rust"
 categories = [
     "api-bindings",
     "authentication",


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂

---

If anything the `homepage` key could/should be set to `https://stytch.com`, but that is optional and outside the goal of this PR.