### PR TITLE
Support OAuth2 error fields in ResponseBase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "2.4.0"
+version = "2.4.1"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,11 @@ pub struct ErrorResponse {
     pub status_code: http::StatusCode,
     pub request_id: String,
 
+    #[serde(alias = "error_type", alias = "error")]
     pub error_type: String,
+    #[serde(alias = "error_message", alias = "error_description")]
     pub error_message: String,
+    #[serde(alias = "error_url", alias = "error_uri")]
     pub error_url: String,
 }
 


### PR DESCRIPTION
Alias the fields to support OAuth2 field names