### PR TITLE
Update slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Follow one of the [integration guides](https://stytch.com/docs/guides) or start 
 
 If you've found a bug, [open an issue](https://github.com/stytchauth/stytch-rust/issues/new)!
 
-If you have questions or want help troubleshooting, join us in [Slack](https://stytch.slack.com/join/shared_invite/zt-2f0fi1ruu-ub~HGouWRmPARM1MTwPESA) or email support@stytch.com.
+If you have questions or want help troubleshooting, join us in [Slack](https://stytch.com/docs/resources/support/overview) or email support@stytch.com.
 
 If you've found a security vulnerability, please follow our [responsible disclosure instructions](https://stytch.com/docs/resources/security-and-trust/security#:~:text=Responsible%20disclosure%20program).
 


### PR DESCRIPTION
Update Slack Invite links to point to the Support landing page as a single source of truth (Slack invite links expire after 400 uses and need to be updated semi frequently).