### PR TITLE
Map uint32 to u32 instead of i32 and change chainId type to string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The minimum supported Rust version (MSRV) of this library is Rust 1.70.
 Use `cargo add stytch` to add this to your `Cargo.toml`:
 
 ```toml
-stytch = "3.2.0"
+stytch = "4.0.0"
 ```
 
 ## Usage

--- a/src/b2b/organizations.rs
+++ b/src/b2b/organizations.rs
@@ -200,6 +200,16 @@ pub struct MemberRoleSource {
     ///   argument to the [Update SAML connection](https://stytch.com/docs/b2b/api/update-saml-connection)
     /// endpoint.
     ///
+    /// `scim_connection_group` – an implicit Role granted by the Member's SCIM connection and group. If the
+    /// Member has
+    ///   a SCIM Member registration with the given connection, and belongs to a specific group within the IdP,
+    /// this role assignment will appear in the list.
+    ///
+    ///   SCIM group implicit role assignments can be updated by passing in the
+    /// `scim_group_implicit_role_assignments`
+    ///   argument to the [Update SCIM connection](https://stytch.com/docs/b2b/api/update-scim-connection)
+    /// endpoint.
+    ///
     #[serde(rename = "type")]
     pub type_: String,
     /// details: An object containing additional metadata about the source assignment. The fields will vary
@@ -214,6 +224,9 @@ pub struct MemberRoleSource {
     ///
     ///   `sso_connection_group` – will contain the `connection_id` of the SAML connection and the name of the
     /// `group`
+    ///   that granted the assignment.
+    ///
+    ///   `scim_connection_group` – will contain the `connection_id` of the SAML connection and the `group_id`
     ///   that granted the assignment.
     ///
     pub details: std::option::Option<serde_json::Value>,
@@ -589,7 +602,7 @@ pub struct SearchRequest {
     /// limit: The number of search results to return per page. The default limit is 100. A maximum of 1000
     /// results can be returned by a single search request. If the total size of your result set is greater than
     /// one page size, you must paginate the response. See the `cursor` field.
-    pub limit: std::option::Option<i32>,
+    pub limit: std::option::Option<u32>,
     /// query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
     /// filter your results. Only an operator is required. If you include no operands, no filtering will be
     /// applied. If you include no query object, it will return all Organizations with no filtering applied.

--- a/src/b2b/organizations_members.rs
+++ b/src/b2b/organizations_members.rs
@@ -265,7 +265,7 @@ pub struct SearchRequest {
     /// limit: The number of search results to return per page. The default limit is 100. A maximum of 1000
     /// results can be returned by a single search request. If the total size of your result set is greater than
     /// one page size, you must paginate the response. See the `cursor` field.
-    pub limit: std::option::Option<i32>,
+    pub limit: std::option::Option<u32>,
     /// query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
     /// filter your results. Only an operator is required. If you include no operands, no filtering will be
     /// applied. If you include no query object, it will return all Members with no filtering applied.

--- a/src/b2b/scim.rs
+++ b/src/b2b/scim.rs
@@ -41,6 +41,12 @@ pub struct Group {
     pub display: String,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IMs {
+    pub value: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Manager {
     pub value: String,
     #[serde(rename = "ref")]
@@ -81,6 +87,7 @@ pub struct SCIMAttributes {
     pub emails: std::vec::Vec<Email>,
     pub phone_numbers: std::vec::Vec<PhoneNumber>,
     pub addresses: std::vec::Vec<Address>,
+    pub ims: std::vec::Vec<IMs>,
     pub name: std::option::Option<Name>,
     pub enterprise_extension: std::option::Option<EnterpriseExtension>,
 }
@@ -142,6 +149,7 @@ pub struct SCIMGroup {
 pub struct SCIMGroupImplicitRoleAssignments {
     /// role_id: The ID of the role.
     pub role_id: String,
+    /// group_id: The ID of the group.
     pub group_id: String,
     pub group_name: String,
 }

--- a/src/b2b/scim_connection.rs
+++ b/src/b2b/scim_connection.rs
@@ -80,7 +80,7 @@ pub struct GetGroupsRequest {
     /// limit: The number of search results to return per page. The default limit is 100. A maximum of 1000
     /// results can be returned by a single search request. If the total size of your result set is greater than
     /// one page size, you must paginate the response. See the `cursor` field.
-    pub limit: std::option::Option<i32>,
+    pub limit: std::option::Option<u32>,
 }
 /// GetGroupsResponse: Response type for `Connection.get_groups`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -204,7 +204,7 @@ pub struct UpdateRequest {
     pub display_name: std::option::Option<String>,
     pub identity_provider: std::option::Option<UpdateRequestIdentityProvider>,
     /// scim_group_implicit_role_assignments: An array of SCIM group implicit role assignments. Each object in
-    /// the array must contain a `group` and a `role_id`.
+    /// the array must contain a `group_id` and a `role_id`.
     pub scim_group_implicit_role_assignments:
         std::option::Option<std::vec::Vec<SCIMGroupImplicitRoleAssignments>>,
 }

--- a/src/consumer/crypto_wallets.rs
+++ b/src/consumer/crypto_wallets.rs
@@ -20,9 +20,12 @@ pub struct SIWEParams {
     /// resources:  A list of information or references to information the user wishes to have resolved as part
     /// of authentication. Every resource must be an RFC 3986 URI.
     pub resources: std::vec::Vec<String>,
-    /// chain_id: The EIP-155 Chain ID to which the session is bound. Defaults to 1.
-    pub chain_id: std::option::Option<i32>,
-    /// statement: A human-readable ASCII assertion that the user will sign.
+    /// chain_id: The EIP-155 Chain ID to which the session is bound. Defaults to 1. Must be the string
+    /// representation of an integer between 1 and 9,223,372,036,854,775,771, inclusive.
+    pub chain_id: std::option::Option<String>,
+    /// statement: A human-readable ASCII assertion that the user will sign. The statement may only include
+    /// reserved, unreserved, or space characters according to RFC 3986 definitions, and must not contain other
+    /// forms of whitespace such as newlines, tabs, and carriage returns.
     pub statement: std::option::Option<String>,
     /// issued_at: The time when the message was generated. Defaults to the current time. All timestamps in our
     /// API conform to the RFC 3339 standard and are expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
@@ -32,7 +35,7 @@ pub struct SIWEParams {
     /// `2021-12-29T12:33:09Z`.
     pub not_before: std::option::Option<chrono::DateTime<chrono::Utc>>,
     /// message_request_id: A system-specific identifier that may be used to uniquely refer to the sign-in
-    /// request.
+    /// request. The `message_request_id` must be a valid pchar according to RFC 3986 definitions.
     pub message_request_id: std::option::Option<String>,
 }
 /// AuthenticateRequest: Request type for `CryptoWallets.authenticate`.
@@ -149,7 +152,7 @@ pub struct SIWEParamsResponse {
     /// uri: An RFC 3986 URI referring to the resource that is the subject of the signing.
     pub uri: String,
     /// chain_id: The EIP-155 Chain ID to which the session is bound.
-    pub chain_id: u32,
+    pub chain_id: String,
     /// resources:  A list of information or references to information the user wishes to have resolved as part
     /// of authentication. Every resource must be an RFC 3986 URI.
     pub resources: std::vec::Vec<String>,

--- a/src/consumer/m2m_clients.rs
+++ b/src/consumer/m2m_clients.rs
@@ -102,7 +102,7 @@ pub struct SearchRequest {
     /// limit: The number of search results to return per page. The default limit is 100. A maximum of 1000
     /// results can be returned by a single search request. If the total size of your result set is greater than
     /// one page size, you must paginate the response. See the `cursor` field.
-    pub limit: std::option::Option<i32>,
+    pub limit: std::option::Option<u32>,
     /// query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
     /// filter your results. Only an operator is required. If you include no operands, no filtering will be
     /// applied. If you include no query object, it will return all results with no filtering applied.

--- a/src/consumer/users.rs
+++ b/src/consumer/users.rs
@@ -542,7 +542,7 @@ pub struct SearchRequest {
     /// limit: The number of search results to return per page. The default limit is 100. A maximum of 1000
     /// results can be returned by a single search request. If the total size of your result set is greater than
     /// one page size, you must paginate the response. See the `cursor` field.
-    pub limit: std::option::Option<i32>,
+    pub limit: std::option::Option<u32>,
     /// query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
     /// filter your results. Only an operator is required. If you include no operands, no filtering will be
     /// applied. If you include no query object, it will return all results with no filtering applied.


### PR DESCRIPTION
Previously, we were mapping `uint32` to `i32`. This PR changes the mapping to `u32`. I also changed the SIWE ChainID type to `string`. This is a major breaking change.