### PR TITLE
Make org_name and org_slug optional in Discovery.Organizations.Create

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "5.4.0"
+version = "6.0.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "5.3.0"
+version = "5.4.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/src/b2b/discovery_organizations.rs
+++ b/src/b2b/discovery_organizations.rs
@@ -28,19 +28,6 @@ pub struct CreateRequest {
     /// or the
     /// [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to create a new Organization and Member.
     pub intermediate_session_token: String,
-    /// organization_name: The name of the Organization. If the name is not specified, a default name will be
-    /// created based on the email used to initiate the discovery flow. If the email domain is a common email
-    /// provider such as gmail.com, or if the email is a .edu email, the organization name will be generated
-    /// based on the name portion of the email. Otherwise, the organization name will be generated based on the
-    /// email domain.
-    pub organization_name: String,
-    /// organization_slug: The unique URL slug of the Organization. A minimum of two characters is required. The
-    /// slug only accepts alphanumeric characters and the following reserved characters: `-` `.` `_` `~`. If the
-    /// slug is not specified, a default slug will be created based on the email used to initiate the discovery
-    /// flow. If the email domain is a common email provider such as gmail.com, or if the email is a .edu email,
-    /// the organization slug will be generated based on the name portion of the email. Otherwise, the
-    /// organization slug will be generated based on the email domain.
-    pub organization_slug: String,
     /// session_duration_minutes: Set the session lifetime to be this many minutes from now. This will start a
     /// new session if one doesn't already exist,
     ///   returning both an opaque `session_token` and `session_jwt` for this session. Remember that the
@@ -64,6 +51,19 @@ pub struct CreateRequest {
     /// `exp`, `nbf`, `iat`, `jti`) will be ignored.
     ///   Total custom claims size cannot exceed four kilobytes.
     pub session_custom_claims: std::option::Option<serde_json::Value>,
+    /// organization_name: The name of the Organization. If the name is not specified, a default name will be
+    /// created based on the email used to initiate the discovery flow. If the email domain is a common email
+    /// provider such as gmail.com, or if the email is a .edu email, the organization name will be generated
+    /// based on the name portion of the email. Otherwise, the organization name will be generated based on the
+    /// email domain.
+    pub organization_name: std::option::Option<String>,
+    /// organization_slug: The unique URL slug of the Organization. A minimum of two characters is required. The
+    /// slug only accepts alphanumeric characters and the following reserved characters: `-` `.` `_` `~`. If the
+    /// slug is not specified, a default slug will be created based on the email used to initiate the discovery
+    /// flow. If the email domain is a common email provider such as gmail.com, or if the email is a .edu email,
+    /// the organization slug will be generated based on the name portion of the email. Otherwise, the
+    /// organization slug will be generated based on the email domain.
+    pub organization_slug: std::option::Option<String>,
     /// organization_logo_url: The image URL of the Organization logo.
     pub organization_logo_url: std::option::Option<String>,
     /// trusted_metadata: An arbitrary JSON object for storing application-specific data or

--- a/src/b2b/sso_oidc.rs
+++ b/src/b2b/sso_oidc.rs
@@ -15,9 +15,11 @@ pub struct CreateConnectionRequest {
     pub organization_id: String,
     /// display_name: A human-readable display name for the connection.
     pub display_name: std::option::Option<String>,
-    /// identity_provider: The identity provider of this connection. For OIDC, the accepted values are
-    /// `generic`, `okta`, and `microsoft-entra`. For SAML, the accepted values are `generic`, `okta`,
-    /// `microsoft-entra`, and `google-workspace`.
+    /// identity_provider: Name of the IdP. Enum with possible values: `classlink`, `cyberark`, `duo`,
+    /// `google-workspace`, `jumpcloud`, `keycloak`, `miniorange`, `microsoft-entra`, `okta`, `onelogin`,
+    /// `pingfederate`, `rippling`, `salesforce`, `shibboleth`, or `generic`.
+    ///
+    /// Specifying a known provider allows Stytch to handle any provider-specific logic.
     pub identity_provider: std::option::Option<CreateConnectionRequestIdentityProvider>,
 }
 /// CreateConnectionResponse: Response type for `OIDC.create_connection`.
@@ -68,9 +70,11 @@ pub struct UpdateConnectionRequest {
     /// jwks_url: The location of the IdP's JSON Web Key Set, used to verify credentials issued by the IdP. This
     /// will be provided by the IdP.
     pub jwks_url: std::option::Option<String>,
-    /// identity_provider: The identity provider of this connection. For OIDC, the accepted values are
-    /// `generic`, `okta`, and `microsoft-entra`. For SAML, the accepted values are `generic`, `okta`,
-    /// `microsoft-entra`, and `google-workspace`.
+    /// identity_provider: Name of the IdP. Enum with possible values: `classlink`, `cyberark`, `duo`,
+    /// `google-workspace`, `jumpcloud`, `keycloak`, `miniorange`, `microsoft-entra`, `okta`, `onelogin`,
+    /// `pingfederate`, `rippling`, `salesforce`, `shibboleth`, or `generic`.
+    ///
+    /// Specifying a known provider allows Stytch to handle any provider-specific logic.
     pub identity_provider: std::option::Option<UpdateConnectionRequestIdentityProvider>,
     /// custom_scopes: Include a space-separated list of custom scopes that you'd like to include. Note that
     /// this list must be URL encoded, e.g. the spaces must be expressed as %20.

--- a/src/b2b/sso_saml.rs
+++ b/src/b2b/sso_saml.rs
@@ -17,9 +17,11 @@ pub struct CreateConnectionRequest {
     pub organization_id: String,
     /// display_name: A human-readable display name for the connection.
     pub display_name: std::option::Option<String>,
-    /// identity_provider: The identity provider of this connection. For OIDC, the accepted values are
-    /// `generic`, `okta`, and `microsoft-entra`. For SAML, the accepted values are `generic`, `okta`,
-    /// `microsoft-entra`, and `google-workspace`.
+    /// identity_provider: Name of the IdP. Enum with possible values: `classlink`, `cyberark`, `duo`,
+    /// `google-workspace`, `jumpcloud`, `keycloak`, `miniorange`, `microsoft-entra`, `okta`, `onelogin`,
+    /// `pingfederate`, `rippling`, `salesforce`, `shibboleth`, or `generic`.
+    ///
+    /// Specifying a known provider allows Stytch to handle any provider-specific logic.
     pub identity_provider: std::option::Option<CreateConnectionRequestIdentityProvider>,
 }
 /// CreateConnectionResponse: Response type for `SAML.create_connection`.
@@ -136,9 +138,11 @@ pub struct UpdateConnectionRequest {
     /// [SSO migration guide](https://stytch.com/docs/b2b/guides/migrations/additional-migration-considerations)
     /// for more info.
     pub alternative_audience_uri: std::option::Option<String>,
-    /// identity_provider: The identity provider of this connection. For OIDC, the accepted values are
-    /// `generic`, `okta`, and `microsoft-entra`. For SAML, the accepted values are `generic`, `okta`,
-    /// `microsoft-entra`, and `google-workspace`.
+    /// identity_provider: Name of the IdP. Enum with possible values: `classlink`, `cyberark`, `duo`,
+    /// `google-workspace`, `jumpcloud`, `keycloak`, `miniorange`, `microsoft-entra`, `okta`, `onelogin`,
+    /// `pingfederate`, `rippling`, `salesforce`, `shibboleth`, or `generic`.
+    ///
+    /// Specifying a known provider allows Stytch to handle any provider-specific logic.
     pub identity_provider: std::option::Option<UpdateConnectionRequestIdentityProvider>,
 }
 /// UpdateConnectionResponse: Response type for `SAML.update_connection`.

--- a/src/consumer/otp_email.rs
+++ b/src/consumer/otp_email.rs
@@ -93,11 +93,11 @@ pub struct SendRequest {
     pub session_jwt: std::option::Option<String>,
     /// login_template_id: Use a custom template for login emails. By default, it will use your default email
     /// template. The template must be a template using our built-in customizations or a custom HTML email for
-    /// Magic links - Login.
+    /// OTP - Login.
     pub login_template_id: std::option::Option<String>,
     /// signup_template_id: Use a custom template for sign-up emails. By default, it will use your default email
     /// template. The template must be a template using our built-in customizations or a custom HTML email for
-    /// Magic links - Sign-up.
+    /// OTP - Sign-up.
     pub signup_template_id: std::option::Option<String>,
 }
 /// SendResponse: Response type for `Email.send`.

--- a/src/consumer/sessions.rs
+++ b/src/consumer/sessions.rs
@@ -24,7 +24,7 @@ pub struct AppleOAuthFactor {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AuthenticationFactor {
     /// type_: The type of authentication factor. The possible values are: `magic_link`, `otp`,
-    ///    `oauth`, `password`, or `sso`.
+    ///    `oauth`, `password`, `email_otp`, or `sso` .
     #[serde(rename = "type")]
     pub type_: AuthenticationFactorType,
     /// delivery_method: The method that was used to deliver the authentication factor. The possible values
@@ -32,7 +32,7 @@ pub struct AuthenticationFactor {
     ///
     ///   `magic_link` – Only `email`.
     ///
-    ///   `otp` – Only `sms`.
+    ///   `otp` –  Either `sms` or `email` .
     ///
     ///   `oauth` – Either `oauth_google` or `oauth_microsoft`.
     ///
@@ -625,6 +625,8 @@ pub enum AuthenticationFactorType {
     Imported,
     #[serde(rename = "recovery_codes")]
     RecoveryCodes,
+    #[serde(rename = "email_otp")]
+    EmailOTP,
 }
 
 pub struct Sessions {


### PR DESCRIPTION
Title. These fields are optional in this method. This is a MAJOR update since changing a variable from String to Option<String> is not backwards compatible.