### PR TITLE
Add IPGEO to DFP rules endpoint

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@1.80
         with:
           components: rustfmt
 
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@1.80
         with:
           components: clippy
 
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@1.80
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "7.6.0"
+version = "7.7.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/src/consumer/fraud.rs
+++ b/src/consumer/fraud.rs
@@ -103,6 +103,12 @@ pub struct Verdict {
     /// is_authentic_device: The assessment of whether this is an authentic device. It will be false if hardware
     /// or browser deception is detected.
     pub is_authentic_device: bool,
+    /// rule_match_type: The type of rule match that was applied (e.g. `VISITOR_ID`), if any. This field will
+    /// only be present if there is a `RULE_MATCH` reason in the list of verdict reasons.
+    pub rule_match_type: std::option::Option<RuleType>,
+    /// rule_match_identifier: The rule that was applied (e.g. a specific visitor ID value), if any. This field
+    /// will only be present if there is a `RULE_MATCH` reason in the list of verdict reasons.
+    pub rule_match_identifier: std::option::Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -116,6 +122,28 @@ pub enum RuleAction {
     BLOCK,
     #[serde(rename = "NONE")]
     NONE,
+}
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub enum RuleType {
+    #[serde(rename = "VISITOR_ID")]
+    #[default]
+    VISITORID,
+    #[serde(rename = "BROWSER_ID")]
+    BROWSERID,
+    #[serde(rename = "VISITOR_FINGERPRINT")]
+    VISITORFINGERPRINT,
+    #[serde(rename = "BROWSER_FINGERPRINT")]
+    BROWSERFINGERPRINT,
+    #[serde(rename = "HARDWARE_FINGERPRINT")]
+    HARDWAREFINGERPRINT,
+    #[serde(rename = "NETWORK_FINGERPRINT")]
+    NETWORKFINGERPRINT,
+    #[serde(rename = "CIDR_BLOCK")]
+    CIDRBLOCK,
+    #[serde(rename = "ASN")]
+    ASN,
+    #[serde(rename = "COUNTRY_CODE")]
+    COUNTRYCODE,
 }
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub enum VerdictAction {

--- a/src/consumer/fraud_rules.rs
+++ b/src/consumer/fraud_rules.rs
@@ -10,33 +10,45 @@ use serde::{Deserialize, Serialize};
 /// SetRequest: Request type for `Rules.set`.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct SetRequest {
-    /// action: The action that should be returned by a fingerprint lookup for that fingerprint or ID with a
-    /// `RULE_MATCH` reason. The following values are valid: `ALLOW`, `BLOCK`, `CHALLENGE`, or `NONE`. If a
-    /// `NONE` action is specified, it will clear the stored rule.
+    /// action: The action that should be returned by a fingerprint lookup for that identifier with a
+    /// `RULE_MATCH` reason. The following values are valid: `ALLOW`, `BLOCK`, `CHALLENGE`, or `NONE`. For
+    /// country codes, `ALLOW` actions are not allowed. If a `NONE` action is specified, it will clear the
+    /// stored rule.
     pub action: RuleAction,
-    /// visitor_id: The visitor ID we want to set a rule for. Only one fingerprint or ID can be specified in the
+    /// visitor_id: The visitor ID we want to set a rule for. Only one identifier can be specified in the
     /// request.
     pub visitor_id: std::option::Option<String>,
-    /// browser_id: The browser ID we want to set a rule for. Only one fingerprint or ID can be specified in the
+    /// browser_id: The browser ID we want to set a rule for. Only one identifier can be specified in the
     /// request.
     pub browser_id: std::option::Option<String>,
-    /// visitor_fingerprint: The visitor fingerprint we want to set a rule for. Only one fingerprint or ID can
-    /// be specified in the request.
+    /// visitor_fingerprint: The visitor fingerprint we want to set a rule for. Only one identifier can be
+    /// specified in the request.
     pub visitor_fingerprint: std::option::Option<String>,
-    /// browser_fingerprint: The browser fingerprint we want to set a rule for. Only one fingerprint or ID can
-    /// be specified in the request.
+    /// browser_fingerprint: The browser fingerprint we want to set a rule for. Only one identifier can be
+    /// specified in the request.
     pub browser_fingerprint: std::option::Option<String>,
-    /// hardware_fingerprint: The hardware fingerprint we want to set a rule for. Only one fingerprint or ID can
-    /// be specified in the request.
+    /// hardware_fingerprint: The hardware fingerprint we want to set a rule for. Only one identifier can be
+    /// specified in the request.
     pub hardware_fingerprint: std::option::Option<String>,
-    /// network_fingerprint: The network fingerprint we want to set a rule for. Only one fingerprint or ID can
-    /// be specified in the request.
+    /// network_fingerprint: The network fingerprint we want to set a rule for. Only one identifier can be
+    /// specified in the request.
     pub network_fingerprint: std::option::Option<String>,
     /// expires_in_minutes: The number of minutes until this rule expires. If no `expires_in_minutes` is
     /// specified, then the rule is kept permanently.
     pub expires_in_minutes: std::option::Option<i32>,
     /// description: An optional description for the rule.
     pub description: std::option::Option<String>,
+    /// cidr_block: The CIDR block we want to set a rule for. You may pass either an IP address or a CIDR block.
+    /// The CIDR block prefix must be between 16 and 32, inclusive. If an end user's IP address is within this
+    /// CIDR block, this rule will be applied. Only one identifier can be specified in the request.
+    pub cidr_block: std::option::Option<String>,
+    /// country_code: The country code we want to set a rule for. The country code must be a valid ISO 3166-1
+    /// alpha-2 code. You may not set `ALLOW` rules for country codes. Only one identifier can be specified in
+    /// the request.
+    pub country_code: std::option::Option<String>,
+    /// asn: The ASN we want to set a rule for. The ASN must be the string representation of an integer between
+    /// 0 and 4294967295, inclusive. Only one identifier can be specified in the request.
+    pub asn: std::option::Option<String>,
 }
 /// SetResponse: Response type for `Rules.set`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -52,22 +64,28 @@ pub struct SetResponse {
     /// are server errors.
     #[serde(with = "http_serde::status_code")]
     pub status_code: http::StatusCode,
-    /// visitor_id: The cookie stored on the user's device that uniquely identifies them.
+    /// visitor_id: The visitor ID that a rule was set for.
     pub visitor_id: std::option::Option<String>,
-    /// browser_id: Combination of VisitorID and NetworkFingerprint to create a clear identifier of a browser.
+    /// browser_id: The browser ID that a rule was set for.
     pub browser_id: std::option::Option<String>,
-    /// visitor_fingerprint: Cookie-less way of identifying a unique user.
+    /// visitor_fingerprint: The visitor fingerprint that a rule was set for.
     pub visitor_fingerprint: std::option::Option<String>,
-    /// browser_fingerprint: Combination of signals to identify a browser and its specific version.
+    /// browser_fingerprint: The browser fingerprint that a rule was set for.
     pub browser_fingerprint: std::option::Option<String>,
-    /// hardware_fingerprint: Combinations of signals to identify an operating system and architecture.
+    /// hardware_fingerprint: The hardware fingerprint that a rule was set for.
     pub hardware_fingerprint: std::option::Option<String>,
-    /// network_fingerprint: Combination of signals associated with a specific network commonly known as TLS
-    /// fingerprinting.
+    /// network_fingerprint: The network fingerprint that a rule was set for.
     pub network_fingerprint: std::option::Option<String>,
     /// expires_at: The timestamp when the rule expires. Values conform to the RFC 3339 standard and are
     /// expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
     pub expires_at: std::option::Option<chrono::DateTime<chrono::Utc>>,
+    /// cidr_block: The CIDR block that a rule was set for. If an end user's IP address is within this CIDR
+    /// block, this rule will be applied.
+    pub cidr_block: std::option::Option<String>,
+    /// country_code: The country code that a rule was set for.
+    pub country_code: std::option::Option<String>,
+    /// asn: The ASN that a rule was set for.
+    pub asn: std::option::Option<String>,
 }
 
 pub struct Rules {


### PR DESCRIPTION
This PR adds support for IPGEO in the fraud rules endpoint. You can now set rules on CIDR blocks, ASNs, and country codes. The fingerprint lookup endpoint will now also return information on which rule type and identifier were applied, if a `RULE_MATCH` reason was returned.