### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.73
+      - uses: dtolnay/rust-toolchain@1.80
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5


### PR DESCRIPTION
The workflow to publish to Crates.io for the last two releases failed due to the following error:

```
 package `native-tls v0.2.14` cannot be built because it requires rustc 1.80.0 or newer, while the currently active rustc version is 1.73.0
 ```

This PR updates the Github action to use rustc 1.80, which should fix the issue. I also manually published versions 7.6.0 and 7.7.0, so we shouldn't need to do a version update in this PR.