### PR TITLE
use 1.18 for auto-publish github workflow to publish to Crates.io

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.80
+      - uses: dtolnay/rust-toolchain@1.81
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5


### PR DESCRIPTION
Use 1.18 for auto-publish github workflow to publish to Crates.io

```
rustc 1.80.1 is not supported by the following packages:
        litemap@0.7.5 requires rustc 1.81
        zerofrom@0.1.6 requires rustc 1.81