### PR TITLE
Expire JWKS every 300 seconds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,10 @@ reqwest = { version = "0.12.4", default-features = false, features = ["json"] }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = "1.0.82"
 thiserror = "1.0.31"
-tokio = { version = "1", features = ["sync"], default-features = false }
+tokio = { version = "1", features = [
+  "macros",
+  "sync",
+], default-features = false }
 tracing = "0.1.35"
 url = "2.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "7.8.0"
+version = "8.0.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The minimum supported Rust version (MSRV) of this library is Rust 1.70.
 Use `cargo add stytch` to add this to your `Cargo.toml`:
 
 ```toml
-stytch = "7.0.0"
+stytch = "8.0.0"
 ```
 
 ## Usage


### PR DESCRIPTION
Current implementation assumes the JWKS will be valid forever, but they expire every six months by default (with a ~1 month overlap where the old and new are both valid). This implementation caches the JWKS for 5 minutes between re-fetches on an as-needed basis.