### PR TITLE
Add webpki-root-certs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ tokio = { version = "1", features = [
 ], default-features = false }
 tracing = "0.1.35"
 url = "2.2.2"
+webpki-root-certs = { version = "1.0.5", optional = true }
 
 [features]
 default = ["rustls"]
 rustls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
+webpki-root-certs = ["rustls", "dep:webpki-root-certs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stytch"
-version = "10.2.0"
+version = "10.3.0"
 edition = "2021"
 license = "MIT"
 description = "Stytch Rust client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ webpki-root-certs = { version = "1.0.5", optional = true }
 default = ["rustls"]
 rustls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
-webpki-root-certs = ["rustls", "dep:webpki-root-certs"]
+webpki-root-certs = ["reqwest/__tls", "dep:webpki-root-certs"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The minimum supported Rust version (MSRV) of this library is Rust 1.70.
 Use `cargo add stytch` to add this to your `Cargo.toml`:
 
 ```toml
-stytch = "10.2"
+stytch = "10.3"
 ```
 
 ## Usage
@@ -164,7 +164,7 @@ The library supports different TLS backends for HTTPS connections:
 To use native-tls instead of the default:
 
 ```toml
-stytch = { version = "10.2", default-features = false, features = ["native-tls"] }
+stytch = { version = "10.3", default-features = false, features = ["native-tls"] }
 ```
 
 **Note:** The default TLS backend changed from `native-tls` to `rustls` in version 10.0. See the migration guide below if upgrading from v9.x.
@@ -176,7 +176,7 @@ certificates to the client instead of adding system root certificates if desired
 To use this feature simply include `stytch` to following way:
 
 ```toml
-stytch = { version = "10.2", features = ["webpki-root-certs"] }
+stytch = { version = "10.3", features = ["webpki-root-certs"] }
 ```
 
 ## Migrating from v9.x to v10.0
@@ -184,6 +184,7 @@ stytch = { version = "10.2", features = ["webpki-root-certs"] }
 ### Breaking Changes
 
 **1. Default TLS backend changed**
+
 - **Previous default:** `native-tls` (platform TLS)
 - **New default:** `rustls` (pure Rust TLS with aws-lc)
 - **Migration:** If you need to keep using native-tls, specify it explicitly:
@@ -192,9 +193,11 @@ stytch = { version = "10.2", features = ["webpki-root-certs"] }
   ```
 
 **2. Feature flags renamed**
+
 - `reqwest-native-tls` → `native-tls`
 - `reqwest-rustls-tls` → `rustls`
 - **Migration:** Update your Cargo.toml feature names:
+
   ```toml
   # Before (v9.x)
   stytch = { version = "9.4", features = ["reqwest-rustls-tls"] }
@@ -205,6 +208,7 @@ stytch = { version = "10.2", features = ["webpki-root-certs"] }
   ```
 
 **3. Crypto providers updated**
+
 - Both JWT verification and HTTPS connections now use aws-lc-rs instead of ring
 - **No code changes required** - this is internal to the library
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The minimum supported Rust version (MSRV) of this library is Rust 1.70.
 Use `cargo add stytch` to add this to your `Cargo.toml`:
 
 ```toml
-stytch = "10.0"
+stytch = "10.2"
 ```
 
 ## Usage
@@ -164,10 +164,20 @@ The library supports different TLS backends for HTTPS connections:
 To use native-tls instead of the default:
 
 ```toml
-stytch = { version = "10.0", default-features = false, features = ["native-tls"] }
+stytch = { version = "10.2", default-features = false, features = ["native-tls"] }
 ```
 
 **Note:** The default TLS backend changed from `native-tls` to `rustls` in version 10.0. See the migration guide below if upgrading from v9.x.
+
+For situations where the system doesn't include CA root certificates (Docker images like Alpine, Debian-slim, etc.) and
+your application is updated frequently you can use the `webpki-root-certs` feature to add the Mozilla trusted root
+certificates to the client instead of adding system root certificates if desired.
+
+To use this feature simply include `stytch` to following way:
+
+```toml
+stytch = { version = "10.2", features = ["webpki-root-certs"] }
+```
 
 ## Migrating from v9.x to v10.0
 


### PR DESCRIPTION
This add a new feature that allows user of this create to merge the webpki root certificates to the `reqwest` client. It allows both system/platform certificates (if they exists) and trusted Mozilla certificates to be used by the TLS backend.

This is useful when an application runs on a bare-bones system that doesn't include CA root certificates. Think Docker images based on Alpine or Debian slim for example. Though, to stay secure such an app must be frequently updated.